### PR TITLE
Force dynamic rendering for file list page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,9 @@ import Link from 'next/link';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 
+// Force dynamic rendering to show newly added files without redeploying
+export const dynamic = 'force-dynamic';
+
 interface FileInfo {
   name: string;
   size: number;


### PR DESCRIPTION
## Summary
Fixes the issue where newly uploaded files to Vercel Blob Storage don't appear on the homepage without redeploying.

## Changes
- Added `export const dynamic = 'force-dynamic'` to the homepage (`src/app/page.tsx`)
- This forces Next.js to render the page on each request instead of statically generating it at build time

## Impact
- Files uploaded to Vercel Blob Storage will now appear immediately on the homepage
- No redeploy required to see new files
- Slight performance tradeoff (dynamic vs static), but negligible for a simple file listing page

## Testing
- Deploy and upload a new file to Vercel Blob Storage
- Refresh the homepage - the new file should appear immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)