### PR TITLE
Add pagination to CSV table viewer

### DIFF
--- a/src/components/CSVTable.tsx
+++ b/src/components/CSVTable.tsx
@@ -6,10 +6,12 @@ import {
   getCoreRowModel,
   getSortedRowModel,
   getFilteredRowModel,
+  getPaginationRowModel,
   flexRender,
   ColumnDef,
   SortingState,
   ColumnFiltersState,
+  PaginationState,
 } from '@tanstack/react-table';
 
 interface CSVTableProps {
@@ -19,6 +21,10 @@ interface CSVTableProps {
 export default function CSVTable({ data }: CSVTableProps) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 10,
+  });
 
   // Generate columns dynamically from the first row
   const columns: ColumnDef<Record<string, string>>[] = data.length > 0
@@ -35,12 +41,15 @@ export default function CSVTable({ data }: CSVTableProps) {
     state: {
       sorting,
       columnFilters,
+      pagination,
     },
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
+    onPaginationChange: setPagination,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
   });
 
   if (data.length === 0) {
@@ -107,8 +116,64 @@ export default function CSVTable({ data }: CSVTableProps) {
           </table>
         </div>
       </div>
-      <div className="text-sm text-muted-foreground mt-4">
-        Showing {table.getRowModel().rows.length} of {data.length} rows
+
+      {/* Pagination Controls */}
+      <div className="flex flex-col sm:flex-row items-center justify-between gap-4 mt-4">
+        {/* Left: Row count info */}
+        <div className="text-sm text-muted-foreground">
+          Showing{' '}
+          {table.getState().pagination.pageIndex *
+            table.getState().pagination.pageSize +
+            1}{' '}
+          to{' '}
+          {Math.min(
+            (table.getState().pagination.pageIndex + 1) *
+              table.getState().pagination.pageSize,
+            table.getFilteredRowModel().rows.length
+          )}{' '}
+          of {table.getFilteredRowModel().rows.length} rows
+        </div>
+
+        {/* Center: Page navigation */}
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+            className="px-3 py-1 border rounded hover:bg-muted transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Previous
+          </button>
+          <span className="text-sm">
+            Page {table.getState().pagination.pageIndex + 1} of{' '}
+            {table.getPageCount()}
+          </span>
+          <button
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+            className="px-3 py-1 border rounded hover:bg-muted transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Next
+          </button>
+        </div>
+
+        {/* Right: Page size selector */}
+        <div className="flex items-center gap-2">
+          <label htmlFor="pageSize" className="text-sm text-muted-foreground">
+            Rows per page:
+          </label>
+          <select
+            id="pageSize"
+            value={table.getState().pagination.pageSize}
+            onChange={(e) => {
+              table.setPageSize(Number(e.target.value));
+            }}
+            className="px-2 py-1 border rounded bg-background text-sm"
+          >
+            <option value={10}>10</option>
+            <option value={50}>50</option>
+            <option value={100}>100</option>
+          </select>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Implemented pagination for CSV table with user-selectable page sizes
- Added page size options: 10, 50, and 100 rows per page
- Ensured sorting and filtering work across entire dataset, not just visible page
- Added responsive pagination controls with Previous/Next navigation

## Changes
- **CSVTable.tsx**: 
  - Added `PaginationState` with default page size of 10 rows
  - Integrated `getPaginationRowModel` from TanStack Table
  - Created pagination control section with:
    - Row count display (showing X to Y of Z rows)
    - Page navigation buttons (Previous/Next with disabled states)
    - Page size selector dropdown (10/50/100 options)
  - Updated row count display to show filtered totals
  - Responsive layout that stacks on mobile devices

## Key Features
✅ Pagination applied AFTER sorting and filtering (correct order of operations)
✅ Sort/filter work on entire dataset, not just current page
✅ Page size selector updates view immediately
✅ Navigation buttons properly disabled at boundaries
✅ Accurate row count shows filtered totals
✅ Responsive design for mobile and desktop

## Test plan
- [x] Build completes successfully with no TypeScript errors
- [x] Verify pagination controls render correctly
- [x] Test page size changes (10, 50, 100)
- [x] Confirm sorting works across all pages
- [x] Confirm filtering works across all pages
- [x] Test navigation buttons at page boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)